### PR TITLE
Improve taxonomy object: each node has a stats() and a results() method

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,27 @@ var treesPromise = require('gramene-trees-client').promise;
 var Q = require('q');
 var _ = require('lodash');
 
+// given two objects that have the same keys and whose values are all integers
+// return a new object that sums them together. If either object is null, return
+// the other one.
+function addCounts(o1, o2) {
+  var result;
+  if(o1 && o2) {
+    result = _.merge(o1, o2, function(a, b) {
+      return a + b;
+    });
+  }
+  else if(o1) {
+    result = o1;
+  }
+  else {
+    result = o2;
+  }
+  return result;
+}
+
 function addGenomesToTaxonomy(taxonomy, genomes) {
+  var taxonomyPrototype = Object.getPrototypeOf(taxonomy);
   taxonomy.leafNodes().forEach(function (speciesNode) {
     var species = speciesNode.model,
       genome = genomes.get(species.id);
@@ -17,28 +37,86 @@ function addGenomesToTaxonomy(taxonomy, genomes) {
     species.genome = genome;
   });
 
-  taxonomy.results = function () { return genomes.results; };
-  taxonomy.binCount = genomes.binCount.bind(genomes);
-  taxonomy.setResults = genomes.setResults.bind(genomes);
+  function calcStatsForTaxonomyNode(node) {
+    var statsFromChildren,
+      statsFromGenome;
 
-  function getNodesAndReturnModel(predicate) {
+    if(node.model.genome) {
+      statsFromGenome = {
+        genomes: 1,
+        genes: node.model.geneCount,
+        bins: node.model.genome.nbins
+      };
+    }
+
+    if(node.children && node.children.length) {
+      statsFromChildren = _.reduce(node.children, function(total, childNode) {
+        return addCounts(total, calcStatsForTaxonomyNode(childNode));
+      }, {genomes: 0, genes: 0, bins: 0});
+    }
+
+    node.model.stats = addCounts(statsFromGenome, statsFromChildren);
+
+    return node.model.stats;
+  }
+
+  calcStatsForTaxonomyNode(taxonomy);
+
+  taxonomyPrototype.genomes = function() {
+    return this.leafNodes().map(function(species) {
+      return species.model.genome;
+    });
+  };
+
+  taxonomyPrototype.results = function () { return this.model.results; };
+  taxonomyPrototype.stats = function () { return this.model.stats; };
+  taxonomy.setResults = function() {
+    genomes.setResults.apply(genomes, arguments);
+
+    function updateCounts(node) {
+      var countFromChildren,
+          countFromGenome;
+
+      if(node.model.genome) {
+        countFromGenome = node.model.genome.results;
+      }
+
+      if(node.children && node.children.length) {
+        countFromChildren = _.reduce(node.children, function(total, childNode) {
+          return addCounts(total, updateCounts(childNode));
+        }, {count: 0, bins: 0});
+      }
+
+      node.model.results = addCounts(countFromGenome, countFromChildren);
+
+      return node.model.results;
+    }
+
+    updateCounts(taxonomy);
+  };
+
+  function getNodesAndReturnModel(self, predicate) {
     return function () {
-      return taxonomy.all(predicate)
+      return this.all(predicate)
         .map(function (node) {
           return node.model;
         });
-    }
+    }.bind(self);
   }
 
-  taxonomy.species = getNodesAndReturnModel(function (node) {
-    return node.model.genome;
-  });
+  taxonomyPrototype.species = function() {
+    return getNodesAndReturnModel(this, function (node) {
+      return node.model.genome;
+    })();
+  };
 
-  taxonomy.speciesWithResults = getNodesAndReturnModel(function (node) {
-    return node.model.genome &&
-      node.model.genome.results &&
-      node.model.genome.results.count;
-  });
+  taxonomyPrototype.speciesWithResults = function() {
+    return getNodesAndReturnModel(this, function (node) {
+      return node.model.genome &&
+        node.model.genome.results &&
+        node.model.genome.results.count;
+    })();
+  }
 }
 
 function removeGenomesFromTaxonomy(taxonomy) {

--- a/index.js
+++ b/index.js
@@ -101,13 +101,13 @@ function addGenomesToTaxonomy(taxonomy, genomes) {
         .map(function (node) {
           return node.model;
         });
-    }.bind(self);
+    }.call(self);
   }
 
   taxonomyPrototype.species = function() {
     return getNodesAndReturnModel(this, function (node) {
       return node.model.genome;
-    })();
+    });
   };
 
   taxonomyPrototype.speciesWithResults = function() {
@@ -115,7 +115,7 @@ function addGenomesToTaxonomy(taxonomy, genomes) {
       return node.model.genome &&
         node.model.genome.results &&
         node.model.genome.results.count;
-    })();
+    });
   }
 }
 


### PR DESCRIPTION
Stats gives you info about how many genomes, genes and bins in the node's subtree, results does the same for result counts and number-of-bins-with-results.
